### PR TITLE
Issue7: mount database on remote filesystem

### DIFF
--- a/bin/romi_scanner_rest_api
+++ b/bin/romi_scanner_rest_api
@@ -9,7 +9,7 @@ from romidata import FSDB as DB
 from flask_cors import CORS
 
 app = Flask(__name__)
-CORS(app)
+# CORS(app)
 api = Api(app)
 
 try:
@@ -20,7 +20,7 @@ except:
 try:
     db_prefix = os.environ["DB_PREFIX"]
 except:
-    db_prefix = "/files/"
+    raise ValueError("DB_LOCATION environment variable is not set")
 
 db = DB(db_location)
 db.connect()
@@ -135,6 +135,11 @@ def fmt_scan(scan):
 
         try:
             res["data"]["angles"]["measured_angles"] = metadata["measures"]["angles"]
+        except:
+            pass
+        
+        try:
+            res["data"]["angles"]["measured_internodes"] = metadata["measures"]["internodes"]
         except:
             pass
 

--- a/bin/romi_scanner_rest_api
+++ b/bin/romi_scanner_rest_api
@@ -9,7 +9,7 @@ from romidata import FSDB as DB
 from flask_cors import CORS
 
 app = Flask(__name__)
-# CORS(app)
+CORS(app)
 api = Api(app)
 
 try:
@@ -20,7 +20,7 @@ except:
 try:
     db_prefix = os.environ["DB_PREFIX"]
 except:
-    raise ValueError("DB_LOCATION environment variable is not set")
+    db_prefix = "/files/"
 
 db = DB(db_location)
 db.connect()
@@ -135,11 +135,6 @@ def fmt_scan(scan):
 
         try:
             res["data"]["angles"]["measured_angles"] = metadata["measures"]["angles"]
-        except:
-            pass
-        
-        try:
-            res["data"]["angles"]["measured_internodes"] = metadata["measures"]["internodes"]
         except:
             pass
 

--- a/romidata/__init__.py
+++ b/romidata/__init__.py
@@ -24,6 +24,7 @@
 # ------------------------------------------------------------------------------
 
 from romidata.fsdb import FSDB
+from romidata.sshfsdb import SSHFSDB
 from romidata.task import RomiTask
 from romidata.task import FilesetTarget
 from romidata.task import DatabaseConfig

--- a/romidata/fsdb.py
+++ b/romidata/fsdb.py
@@ -185,14 +185,6 @@ class FSDB(db.DB):
 
         """
         super().__init__()
-        # Check the given path to root directory of the database is a directory:
-        if not os.path.isdir(basedir):
-            raise IOError("Not a directory: %s" % basedir)
-        # Check the given path to root directory of the database is a "romi db", ie. have the `MARKER_FILE_NAME`:
-        if not _is_db(basedir):
-            raise IOError(
-                "Not a DB. Check that there is a marker named %s in %s" % (
-                    MARKER_FILE_NAME, basedir))
         # Defines attributes:
         self.basedir = basedir
         self.lock_path = os.path.abspath(os.path.join(basedir, LOCK_FILE_NAME))
@@ -221,6 +213,14 @@ class FSDB(db.DB):
         True
 
         """
+        # Check the given path to root directory of the database is a directory:
+        if not os.path.isdir(self.basedir):
+            raise IOError("Not a directory: %s" % self.basedir)
+        # Check the given path to root directory of the database is a "romi db", ie. have the `MARKER_FILE_NAME`:
+        if not _is_db(self.basedir):
+            raise IOError(
+                "Not a DB. Check that there is a marker named %s in %s" % (
+                    MARKER_FILE_NAME, self.basedir))
         if not self.is_connected:
             try:
                 with open(self.lock_path, "x") as _:

--- a/romidata/sshfsdb.py
+++ b/romidata/sshfsdb.py
@@ -1,0 +1,156 @@
+# -*- python -*-
+# -*- coding: utf-8 -*-
+# 
+# romidata - Data handling tools for the ROMI project
+# 
+# Copyright (C) 2018-2019 Sony Computer Science Laboratories
+# Authors: D. Colliaux, T. Wintz, P. Hanappe
+# 
+# This file is part of romidata.
+# 
+# romidata is free software: you can redistribute it
+# and/or modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation, either
+# version 3 of the License, or (at your option) any later version.
+# 
+# romidata is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU Lesser General Public
+# License along with romidata.  If not, see <https://www.gnu.org/licenses/>.
+# ------------------------------------------------------------------------------
+
+
+"""
+romidata.sshfsdb
+=============
+
+Implementation of a database as a file structure on a remote server
+using SSHFS.
+
+"""
+
+import atexit
+import glob
+import os
+import sys
+import subprocess
+import json
+import copy
+from shutil import copyfile
+
+from romidata import db, fsdb, io
+from romidata.db import DBBusyError
+
+MARKER_FILE_NAME = "romidb"  # This file must exist in the root of a folder for it to be considered a valid DB
+LOCK_FILE_NAME = "lock"  # This file prevents opening the DB if it is present in the root folder of a DB
+
+
+class SSHFSDB(fsdb.FSDB):
+    """Subclass of FSDB that first mounts a remote directory using SSHFS.
+
+    Implementation of a database on a remote file system:
+
+    Attributes
+    ----------
+    basedir : str
+        Path to the local directory where to mount the remote directory.
+    remotedir : str
+        Path to the remote directory containing the database. Should be in the format user@server:path
+    scans : list
+        List of `Scan` objects found in the database
+    is_connected : bool
+        ``True`` if the DB is connected (locked the directory), else ``False
+
+    """
+
+    def __init__(self, basedir, remotedir=None):
+        """Database constructor.
+
+        Mount ``remotedir`` directory on the ``basedir`` directory and
+        load accessible ``Scan`` objects.
+
+        Parameters
+        ----------
+        basedir : str
+            Path to local directory of the database
+        remotedir : str
+            Path to the remote directory containing the database. Should be in the format user@server:path
+
+        Examples
+        --------
+        >>> # EXAMPLE 1: Use a temporary dummy database:
+        >>> from romidata import SSHFSDB
+        >>> db = sshfsdb.SSHFSDB("db", "someone@example.com:/data")
+        >>> print(db.basedir)
+        db
+        >>> print(db.remotedir)
+        someone@example.com:/data
+        >>> # Now connecting to this remote DB...
+        >>> db.connect()
+        >>> # ...allows to create new `Scan` in it:
+        >>> new_scan = db.create_scan("007")
+        >>> print(type(new_scan))
+        <class 'romidata.fsdb.Scan'>
+        >>> db.disconnect()
+
+        """
+        super().__init__(basedir)
+        self.remotedir = remotedir
+
+    def connect(self, login_data=None):
+        """Connect to the remote database.
+
+        Handle DB "locking" system by adding a `LOCK_FILE_NAME` file in the DB.
+
+        Parameters
+        ----------
+        login_data : bool
+            UNUSED
+
+        Examples
+        --------
+        >>> from romidata import SSHFSDB
+        >>> db = SSHFSDB("db", "someone@example.com:/data")
+        >>> print(db.is_connected)
+        False
+        >>> db.connect()
+        >>> print(db.is_connected)
+        True
+
+        """
+        if not os.path.isdir(self.basedir):
+            os.makedirs(self.basedir, exist_ok=True)
+        if self.remotedir is not None:
+            cmd = ["sshfs", "-o", "idmap=user",
+                   self.remotedir, self.basedir]
+            print(cmd)
+            p = subprocess.run(cmd)
+            print("The exit code was: %d" % p.returncode)
+        super().connect()
+
+    def disconnect(self):
+        """Disconnect from the database.
+
+        Handle DB "locking" system by removing the `LOCK_FILE_NAME` file from the DB.
+
+        Examples
+        --------
+        >>> from romidata import SSHFSDB
+        >>> db = SSHFSDB("db", "someone@example.com:/data")
+        >>> print(db.is_connected)
+        False
+        >>> db.connect()
+        >>> print(db.is_connected)
+        True
+        >>> db.disconnect()
+        >>> print(db.is_connected)
+        False
+
+        """
+        super().disconnect()
+        p = subprocess.run(["fusermount", "-u", self.basedir])
+        print("The exit code was: %d" % p.returncode)
+        


### PR DESCRIPTION
This change adds a new class, SSHFSDB, subclass of FSDB.

Before loading the database structure, SSHFSDB mounts a remote directory using SSHFS in connect(). The remote filesystem is unmounted in disconnect(). Other than that, SSHFSDB inherits all code implementation from FSDB.

There are some small changes in FSDB: the existence of the base directory and of the "romidb" file are verified in connect() and not in the constructor, as before.
